### PR TITLE
ci: add test steps to the deployment workflow of backend

### DIFF
--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -64,11 +64,6 @@ jobs:
         run: npm run build
         working-directory: backend
 
-      - uses: actions/upload-artifact@v4
-        with:
-          name: dist
-          path: backend/dist
-
   test:
     needs: [build, lint]
     runs-on: ubuntu-22.04
@@ -86,11 +81,6 @@ jobs:
       - name: Install dependencies
         run: npm ci --no-audit --no-fund
         working-directory: backend
-      
-      - uses: actions/download-artifact@v4
-        with:
-          name: dist
-          path: backend/dist
 
       - name: Run tests
         run: npm test

--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -96,7 +96,5 @@ jobs:
         run: npm test
         working-directory: backend
 
-        
-# TODO: Tests
+    
 # TODO: Deploy in some service
-# TODO: Add needs to the jobs

--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -59,6 +59,42 @@ jobs:
         run: npm ci --no-audit --no-fund
         working-directory: backend
 
+      - name: Build
+        run: npm run build
+        working-directory: backend
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: backend/dist
+
+  test:
+    needs: [build, lint]
+    runs-on: ubuntu-22.04
+    steps:
+
+      - uses: actions/checkout@v4 # Clones the repository with just latest commit
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4  # Sets up node environment
+        with:
+          node-version: 18
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci --no-audit --no-fund
+        working-directory: backend
+      
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: backend/dist
+
+      - name: Run tests
+        run: npm test
+        working-directory: backend
+
         
 # TODO: Tests
 # TODO: Deploy in some service

--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -25,12 +25,13 @@ jobs:
   lint: 
     runs-on: ubuntu-22.04
     steps:
-
-      - uses: actions/checkout@v4 # Clones the repository with just latest commit
+      - name: Checkout Repository
+        uses: actions/checkout@v4 # Clones the repository with just latest commit
         with:
           fetch-depth: 0
-
-      - uses: actions/setup-node@v4  # Sets up node environment
+      
+      - name: Setup Node.js
+        uses: actions/setup-node@v4  # Sets up node environment
         with:
           node-version: 18
           cache: 'npm'
@@ -47,11 +48,13 @@ jobs:
     runs-on: ubuntu-22.04 # The runner to use
     steps:
 
-      - uses: actions/checkout@v4 # Clones the repository with just latest commit 
+      - name: Checkout Repository
+        uses: actions/checkout@v4 # Clones the repository with just latest commit
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@v4  # Sets up node environment
+      - name: Setup Node.js
+        uses: actions/setup-node@v4  # Sets up node environment
         with:
           node-version: 18
           cache: 'npm'
@@ -69,15 +72,17 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
 
-      - uses: actions/checkout@v4 # Clones the repository with just latest commit
+      - name: Checkout Repository
+        uses: actions/checkout@v4 # Clones the repository with just latest commit
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@v4  # Sets up node environment
+      - name: Setup Node.js
+        uses: actions/setup-node@v4  # Sets up node environment
         with:
           node-version: 18
           cache: 'npm'
-
+  
       - name: Install dependencies
         run: npm ci --no-audit --no-fund
         working-directory: backend

--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -1,15 +1,19 @@
-name: Deployment Pipeline
+name: Deploy API
 
 on:
   push:
     branches:
       - main
+    paths:
+      - 'backend/**'
   pull_request:
     branches:
       - main
     types:
       - opened
       - synchronize
+    paths:
+      - 'backend/**'
 
 concurrency:
   group: ci-${{ github.ref }} # This will make sure that only one workflow runs at a time

--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -14,6 +14,7 @@ on:
       - synchronize
     paths:
       - 'backend/**'
+      - '.github/workflows/deploy-api.yml'
 
 concurrency:
   group: ci-${{ github.ref }} # This will make sure that only one workflow runs at a time

--- a/.github/workflows/deploy-docusaurus.yml
+++ b/.github/workflows/deploy-docusaurus.yml
@@ -6,17 +6,23 @@ on:
       - main
   workflow_dispatch:
 
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       contents: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci --no-audit --no-fund
         working-directory: docs
 
       - name: Build Docusaurus

--- a/.github/workflows/vale-lint.yml
+++ b/.github/workflows/vale-lint.yml
@@ -10,21 +10,26 @@ on:
       - '*'
   workflow_dispatch: # Allow manual triggering from the Actions tab.
 
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   prose:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
-      # Step 1: Check out the repository code.
-      - name: Checkout Code
-        uses: actions/checkout@v3 
 
-      # Step 2: Set up Node.js
-      - name: Setup Node.js
-        uses: actions/setup-node@v3
+      - name: Checkout Repository
+        uses: actions/checkout@v4
         with:
-          node-version: 16 # Use Node.js 16 or higher
+          fetch-depth: 0
 
-      # Step 3: Run Vale lint checks.
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: 'npm'
+
       - name: Vale Lint
         uses: errata-ai/vale-action@reviewdog
         with:


### PR DESCRIPTION
Adds trigger to deploy API workflow to execute tests when build and lint passed.
![image](https://github.com/user-attachments/assets/ea0158a0-f12b-4525-9abc-d990ab778215)

Also updates Docusaurus-deploy and vale-lint workflows to use Ubuntu 22.04 and latest action versions.
